### PR TITLE
Master subnet validations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache: pip
 
 python:
-  - "3.5"
+  - "3.7-dev"
 
 branches:
   only:

--- a/django_ipam/base/models.py
+++ b/django_ipam/base/models.py
@@ -45,6 +45,10 @@ class AbstractSubnet(TimeStampedEditableModel):
                 raise ValidationError({
                     'subnet': _('Subnet overlaps with %s') % subnet['subnet']
                 })
+        if self.master_subnet and not ip_network(self.subnet).subnet_of(ip_network(self.master_subnet)):
+            raise ValidationError({
+                'master_subnet': _('Invalid master subnet')
+            })
 
     def get_first_available_ip(self):
         ipaddress_set = [ip.ip_address for ip in self.ipaddress_set.all()]

--- a/django_ipam/tests/base/test_models.py
+++ b/django_ipam/tests/base/test_models.py
@@ -131,6 +131,17 @@ class BaseTestModel(object):
         if failed:
             self.fail('ValidationError not raised')
 
+    def test_invalid_master_subnet(self):
+        failed = True
+        subnet = self._create_subnet(subnet='10.20.0.0/24')
+        try:
+            self._create_subnet(subnet='192.168.2.0/24', master_subnet=subnet)
+        except ValidationError as e:
+            self.assertTrue(e.message_dict['master_subnet'] == ['Invalid master subnet'])
+            failed = False
+        if failed:
+            self.fail('ValidationError not raised')
+
     def test_save_none_subnet_fails(self):
         failed = True
         try:


### PR DESCRIPTION
I had to upgrade to Python 3.7 for this to work. The functions `subnet_of` etc. are newly implemented in `3.7`. - https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Network.subnet_of