### PR TITLE
[add]Adding 127.0.0.1 to ALLOWED_HOSTS #69

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,7 +3,7 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7&cb7ybp)-z@f5ow8jryz=0*b!@4ma%e#bl2$z!+_g!i3*8=k_'
 DEBUG = True
-ALLOWED_HOSTS = ['localhost']
+ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'django.contrib.auth',


### PR DESCRIPTION
People are getting Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add '127.0.0.1' to ALLOWED_HOSTS when they try to access 127.0.0.1 instead of localhost. So, adding it to ALLOWED_HOSTS

Fixes #69