### PR TITLE
[minor/chores] cleanup

### DIFF
--- a/django_ipam/static/django-ipam/js/subnet.js
+++ b/django_ipam/static/django-ipam/js/subnet.js
@@ -62,7 +62,6 @@ function initHostsInfiniteScroll($, current_subnet, address_add_url) {
             success: function (res) {
                 fetchedPages.push(res.results);
                 nextPageUrl = res.next;
-                console.log(nextPageUrl);
                 appendPage();
             },
             error: function (error) {


### PR DESCRIPTION
Seems someone forgot to remove the `console.log()`