### PR TITLE
[subnet-visualizer] Scroller should remember last page #100

### DIFF
--- a/django_ipam/base/admin.py
+++ b/django_ipam/base/admin.py
@@ -158,9 +158,9 @@ class AbstractIpAddressAdmin(TimeReadonlyAdminMixin, ModelAdmin):
         """
         response = super().response_add(request, *args, **kwargs)
         if request.POST.get('_popup'):
-            return HttpResponse("""
+            return HttpResponse(f"""
                <script type='text/javascript'>
-                  opener.dismissAddAnotherPopup(window);
+                  opener.dismissAddAnotherPopup(window, '{request.POST.get('ip_address')}');
                </script>
              """)
         return response

--- a/django_ipam/static/django-ipam/js/subnet.js
+++ b/django_ipam/static/django-ipam/js/subnet.js
@@ -1,10 +1,17 @@
 /*jslint browser:true */
 /*globals onUpdate*/
 
-function dismissAddAnotherPopup(win) {
+function normalizeIP(ip_address) {
+    'use strict';
+    return ip_address ? ip_address.split(':').join('').split('.').join('') : null;
+}
+
+function dismissAddAnotherPopup(win, ip_address) {
     'use strict';
     win.close();
-    window.location.reload();
+    var id = normalizeIP(ip_address);
+    var host = django.jQuery('#addr_' + id);
+    host.replaceWith('<a class="used" id="addr_' + id + '">' + ip_address + '</a>');
 }
 
 django.jQuery(function ($) {
@@ -30,11 +37,13 @@ function initHostsInfiniteScroll($, current_subnet, address_add_url) {
         nextPageUrl = '/api/v1/subnet/' + current_subnet + '/hosts',
         lastRenderedPage = 0; //1 based indexing (0 -> no page rendered)
     function addressListItem(addr) {
+        var id = normalizeIP(addr.address);
         if (addr.used) {
-            return '<a class="used">' + addr.address + '</a>';
+            return '<a class="used" id="addr_' + id + '">' + addr.address + '</a>';
         }
         return '<a href=\"' + address_add_url + '?_to_field=id&amp;_popup=1&amp;ip_address=' +
-            addr.address + '&amp;subnet=' + current_subnet + '"onclick="return showAddAnotherPopup(this);">' +
+            addr.address + '&amp;subnet=' + current_subnet + '"onclick="return showAddAnotherPopup(this);" ' +
+            'id="addr_' + id + '">' +
             addr.address + '</a>';
     }
     function pageContainer(page) {
@@ -106,3 +115,4 @@ function initHostsInfiniteScroll($, current_subnet, address_add_url) {
     $('.subnet-visual').scroll(onUpdate);
     onUpdate();
 }
+

--- a/django_ipam/tests/base/test_admin.py
+++ b/django_ipam/tests/base/test_admin.py
@@ -96,7 +96,7 @@ class BaseTestAdmin(object):
                                     _popup=1)
         response = self.client.post(reverse('admin:{0}_ipaddress_add'.format(self.app_name)),
                                     json.loads(post_data))
-        self.assertContains(response, 'opener.dismissAddAnotherPopup(window);')
+        self.assertContains(response, 'opener.dismissAddAnotherPopup(window, \'10.0.0.1\');')
 
     def test_csv_upload(self):
         csv_data = """Monachers - Matera,


### PR DESCRIPTION
Rather than reloading the entire page or the entire subnet host as described in the issue, the style of the individual subnet on the list gets updated
with the class="used". That is, it changes the background color to red and removes the href attribute from the element.

Fixes #100